### PR TITLE
💄 방장용 uI 전체

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import MyPagePage from "../src/ui/pages/MyPagePage";
 import AuthPage from "../src/ui/pages/AuthPage";
 import FindIdPage from "../src/ui/pages/FindIdPage";
 import FindPwPage from "../src/ui/pages/FindPwPage";
+import HostMainPage from "../src/ui/pages/HostMainPage";
 import routes from "./routes/routes";
 
 function App() {
@@ -21,6 +22,7 @@ function App() {
         <Route path={routes.AUTHPAGE} element={<AuthPage />} />
         <Route path={routes.FINDID} element={<FindIdPage />} />
         <Route path={routes.FINDPW} element={<FindPwPage />} />
+        <Route path={routes.HOSTMAIN} element={<HostMainPage/>}/>
       </Routes>
     </BrowserRouter>
   );

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -7,6 +7,7 @@ const routes = {
   MAKENEW: "makenew/",
   MYPAGE: "mypage/",
   AUTHPAGE: "authpage/",
+  HOSTMAIN: "hostmain/",
 };
 
 export default routes;

--- a/src/ui/components/main/Host/HostMainReport/Report.js
+++ b/src/ui/components/main/Host/HostMainReport/Report.js
@@ -1,0 +1,19 @@
+import styled from "styled-components";
+
+import ReportList from "./ReportList";
+import icon from "../../../../../assets/icon_alert.png";
+import MainSubTitle from "../../MainSubTitle";
+
+export default function Report() {
+  return (
+    <Wrapper>
+      <MainSubTitle iconSrc={icon} title={"00월 0주차 신고 내역"} />
+      <div style={{ marginBottom: "15px" }}></div>
+      <ReportList />
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  margin-bottom: 40px;
+`;

--- a/src/ui/components/main/Host/HostMainReport/ReportBox.js
+++ b/src/ui/components/main/Host/HostMainReport/ReportBox.js
@@ -1,0 +1,30 @@
+import styled from "styled-components";
+import ReportItem from "./ReportItem";
+
+export default function ReportBox({ reportList }) {
+  return (
+    <Wrapper>
+      <ReportItem report={reportList[0]} />
+      <Divider />
+      <ReportItem report={reportList[1]} />
+      <Divider />
+      <ReportItem report={reportList[2]} />
+      <Divider />
+      <ReportItem report={reportList[3]} />
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding-top: 24px;
+  padding-bottom: 24px;
+  height: 335px;
+`;
+
+const Divider = styled.div`
+  height: 16px;
+  display: flex;
+`;

--- a/src/ui/components/main/Host/HostMainReport/ReportItem.js
+++ b/src/ui/components/main/Host/HostMainReport/ReportItem.js
@@ -1,0 +1,37 @@
+import styled from "styled-components";
+import { Subtitle1, Subtitle2 } from "../../../../../core/texts";
+import { Body2 } from "../../../../../core/texts";
+
+export default function ReportItem({report}){
+  return(
+    <Wrapper>
+      <Subtitle2>{report.index}</Subtitle2>
+      <Body2>{report.date}</Body2>
+      <Body2>신고자 {report.reporter}님</Body2>
+      <Body2>{report.reported}님 게시물 신고</Body2>
+      <Subtitle2>{report.crtidate} 인증</Subtitle2>
+      <MoreBtn>자세히 보기</MoreBtn>
+    </Wrapper>
+  )
+}
+
+const Wrapper = styled.div`
+display:flex;
+height:76px;
+width: 1600px;
+justify-content: space-around;
+align-items: center;
+border: 3px solid black;
+border-radius: 5px;
+`
+
+const MoreBtn = styled.div`
+width:108px;
+height:48px;
+display:flex;
+justify-content:center;
+align-items:center;
+background-color: black;
+border-radius: 5px;
+color: white;
+`

--- a/src/ui/components/main/Host/HostMainReport/ReportList.js
+++ b/src/ui/components/main/Host/HostMainReport/ReportList.js
@@ -1,0 +1,59 @@
+import styled from "styled-components";
+import { gray100 } from "../../../../../core/colors";
+import ReportBox from "./ReportBox";
+
+const REPORT_DATA = [
+  {
+    index: "01",
+    date: "22.03.31",
+    reporter: "가재",
+    reported: "시바",
+    crtidate: "2022년 3월 26일자",
+  },
+  {
+    index: "02",
+    date: "22.03.31",
+    reporter: "가재",
+    reported: "시바",
+    crtidate: "2022년 3월 26일자",
+  },
+  {
+    index: "03",
+    date: "22.03.31",
+    reporter: "가재",
+    reported: "시바",
+    crtidate: "2022년 3월 26일자",
+  },
+  {
+    index: "04",
+    date: "22.03.31",
+    reporter: "가재",
+    reported: "시바",
+    crtidate: "2022년 3월 26일자",
+  },
+];
+
+export default function ReportList() {
+  return (
+    <Wrapper>
+      <ReportBox reportList={REPORT_DATA} />
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  height: 335px;
+  background-color: ${gray100};
+  border: 3px solid black;
+  border-radius: 5px;
+  align-items: stretch;
+  overflow-y: scroll;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+`;

--- a/src/ui/components/main/Host/HostRainking.js
+++ b/src/ui/components/main/Host/HostRainking.js
@@ -1,0 +1,40 @@
+import RankingList from "../ranking/RankingList";
+import rankicon from "../../../../assets/icon_rank.png";
+import MainSubTitle from "../MainSubTitle";
+import styled from "styled-components";
+import { button2Color } from "../../../../core/colors";
+import { Button } from "../../../../core/texts";
+
+export default function HostRanking() {
+  return (
+    <Wrapper>
+      <TitleWrapper>
+      <MainSubTitle iconSrc={rankicon} title={"0월 0주차 랭킹"} />
+      <LinkCopyBtn><Button>초대 링크 복사하기</Button></LinkCopyBtn>
+      </TitleWrapper>
+      <RankingList />
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  margin-bottom: 40px;
+`;
+
+const TitleWrapper=styled.div`
+display:flex;
+justify-content:space-between;
+`
+
+
+
+const LinkCopyBtn = styled.div`
+width: 168px;
+height: 40px;
+border-radius: 5px;
+display: flex;
+justify-content: center;
+align-items: center;
+background-color: ${button2Color};
+margin-bottom: 10px;
+`

--- a/src/ui/components/main/Host/StudySetting.js
+++ b/src/ui/components/main/Host/StudySetting.js
@@ -1,0 +1,22 @@
+import styled from "styled-components";
+import icon from "../../../../assets/icon_setting.png";
+import { Subtitle1 } from "../../../../core/texts";
+
+export default function StudySetting() {
+  return (
+    <Wrapper>
+      <SettingIcon src={icon} />
+      <Subtitle1>스터디 설정 ▶ </Subtitle1>
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  display: flex;
+  margin-top: 28px;
+`;
+const SettingIcon = styled.img`
+  width: 20px;
+  height: 20px;
+  margin-right: 10px;
+`;

--- a/src/ui/components/mypage/Listbar.js
+++ b/src/ui/components/mypage/Listbar.js
@@ -3,6 +3,8 @@ import { gray100 } from "../../../core/colors";
 import ListBarStudyList from "./ListBarStudyList";
 import ArrowBtn from "./ArrowBtn";
 
+// 폴더 이름 변경 커밋
+
 export default function ListBar() {
   return (
     <ListBarBox>

--- a/src/ui/pages/HostMainPage.js
+++ b/src/ui/pages/HostMainPage.js
@@ -1,0 +1,41 @@
+import styled from "styled-components";
+import Header from "../components/header/Header";
+import Mcalendar from "../components/main/calendar/Mcalendar";
+import Notice from "../components/main/notice/Notice";
+import HostRanking from "../components/main/Host/HostRainking";
+import Rule from "../components/main/rule/Rule";
+import StudyInfo from "../components/main/study-info/StudyInfo";
+import Report from "../components/main/Host/HostMainReport/Report";
+import SideBar from "../components/sidebar/SideBar";
+import StudySetting from "../components/main/Host/StudySetting";
+
+export default function HostMainPage() {
+  return (
+    <Wrapper>
+      <SideBar />
+      <MainContext>
+        <Header />
+        <StudySetting/>
+        <StudyInfo />
+        <Mcalendar />
+        <HostRanking />
+        <Report/>
+        <Rule />
+        <Notice />
+      </MainContext>
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  display: flex;
+  width: 100vw;
+  height: 100vh;
+`;
+
+const MainContext = styled.div`
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  margin: 58px 90px 58px 288px;
+`;


### PR DESCRIPTION
1. component>main>Host폴더 추가
2. routes.js에 HOSTMAIN:"hostmain/" 추가
3.App.js에 routes.HOSTMAIN 추가

4. 1번의 Host 폴더에 방장 페이지 UI 추가 구현
1)신고 내역-Report.js (관련된 모든 파일 앞에 Report를 붙였습니다.)
2)스터디 설정(헤더 위에)-StudySetting.js
3)초대 링크 복사하기 포함된 랭킹-HostMainPage.js